### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER 1001
 
 ADD . $HOME
 
-RUN npm ci --ignore-scripts && tsc --project tsconfig.build.json
+RUN npm ci --ignore-scripts && npm run build
 
 EXPOSE 4000
 


### PR DESCRIPTION
Use npm build instead of directly calling tsc so the post-build step that copies the static files into the dist directory also runs.